### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# fluent-plugin-route, a plugin for [Fluentd](http://fluentd.org)
+# fluent-plugin-route
 
-Fluentd output plugin to rewrite tags to route messages.
+[Fluentd](http://fluentd.org) output plugin to rewrite tags to route messages.
 
 ## Configuration
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
